### PR TITLE
Enable continuous integration with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2.1
+orbs:
+  docker: circleci/docker@1.7.0
+jobs:
+  build_and_test:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - setup_remote_docker:
+          version: 20.10.14
+      - checkout
+      - docker/build:
+          attach-at: ./
+          debug: true
+          dockerfile: devDockerfile 
+          image: rnamake_dev
+          tag: latest
+          path: ./docker/
+      - run:
+          name: Run
+          command: docker run -d -i --name rnamake_dev rnamake_dev
+      - run:
+          name: Test
+          command: docker exec rnamake_dev ctest --test-dir RNAMake/cmake/build
+
+workflows:
+  validate_changes:
+    jobs:
+      - build_and_test

--- a/build_docker_images
+++ b/build_docker_images
@@ -1,0 +1,2 @@
+docker build -t rnamake -f docker/Dockerfile .
+docker build -t rnamake_dev -f docker/devDockerfile


### PR DESCRIPTION
First push with `.circleci/config.yml`, let's see what breaks